### PR TITLE
add options pages support

### DIFF
--- a/src/ManifestAsset.js
+++ b/src/ManifestAsset.js
@@ -117,10 +117,10 @@ class ManifestAsset extends Asset {
 
         const options = this.ast[nodeName]
         if (options.page) {
-            this.processSingleDependency(options.page)
+            options.page = this.processSingleDependency(options.page)
             this.isAstDirty = true
         } else if (options) {
-            this.processSingleDependency(options)
+            this.ast[nodeName] = this.processSingleDependency(options)
             this.isAstDirty = true
         }
     }

--- a/src/ManifestAsset.js
+++ b/src/ManifestAsset.js
@@ -110,6 +110,21 @@ class ManifestAsset extends Asset {
         }
     }
 
+    processOptionsPage(nodeName) {
+        if(!['options_ui', 'options_page'].includes(nodeName)) {
+            return
+        }
+
+        const options = this.ast[nodeName]
+        if (options.page) {
+            this.processSingleDependency(options.page)
+            this.isAstDirty = true
+        } else if (options) {
+            this.processSingleDependency(options)
+            this.isAstDirty = true
+        }
+    }
+
     processIcons(nodeName) {
         if (nodeName !== 'icons') {
             return
@@ -128,6 +143,7 @@ class ManifestAsset extends Asset {
             this.processContentScripts(nodeName)
             this.processWebAccessibleResources(nodeName)
             this.processBrowserOrPageAction(nodeName)
+            this.processOptionsPage(nodeName)
             this.processIcons(nodeName)
         }
     }

--- a/test/integration/web-extension/manifest.json
+++ b/test/integration/web-extension/manifest.json
@@ -30,6 +30,9 @@
         "default_title": "Example Web Extension",
         "default_popup": "popup.html"
     },
+    "options_ui": {
+        "page": "options.html"
+    },
     "web_accessible_resources": [
         "inject.js"
     ]

--- a/test/integration/web-extension/options.html
+++ b/test/integration/web-extension/options.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+
+<head>
+    <script src="options/index.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/integration/web-extension/options/index.js
+++ b/test/integration/web-extension/options/index.js
@@ -1,0 +1,5 @@
+main()
+
+function main() {
+    console.log('Hello, world!')
+}

--- a/test/web-extension.js
+++ b/test/web-extension.js
@@ -16,6 +16,7 @@ describe('WebExtension', () => {
                 { name: 'content_script.js' },
                 { name: 'favicon.ico' },
                 { name: 'inject.js' },
+                { name: 'options.html' },
                 { name: 'popup.html' }
             ]
         })


### PR DESCRIPTION
This plugin is just I wanted! I appreciate it!
Anyway, there is one lacking feature for me; options pages.

[https://developer.mozilla.org/en-US/Add-ons/WebExtensions/user_interface/Options_pages]

Please consider to process `options_ui` key and `options_page` key in `manifest.json` for WebExtension.

note: `options_page` is a [deprecated key](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json#Browser_compatibility).