### PR TITLE
Parcel dependency moved to non-devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "homepage": "https://github.com/kevincharm/parcel-plugin-web-extension#readme",
   "devDependencies": {
     "cross-env": "^5.1.6",
-    "mocha": "^5.2.0",
-    "parcel-bundler": "^1.9.0"
+    "mocha": "^5.2.0"
   },
   "dependencies": {
-    "fast-glob": "^2.2.2"
+    "fast-glob": "^2.2.2",
+    "parcel-bundler": "^1.9.0"
   }
 }


### PR DESCRIPTION
Makes more sense to have it in "non-devDependencies", that it is installed when missing (especially when there are 2 of them in npm register).