### PR TITLE
override replaceBundleNames to always emit POSIX paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "fast-glob": "^2.2.2",
-    "parcel-bundler": "^1.9.0"
+    "parcel-bundler": "^1.9.0",
+    "upath": "^1.1.0"
   }
 }

--- a/src/ManifestAsset.js
+++ b/src/ManifestAsset.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const upath = require('upath')
 const glob = require('fast-glob')
 const Asset = require('parcel-bundler/src/Asset')
 const JSONAsset = require('parcel-bundler/src/assets/JSONAsset')
@@ -31,6 +32,14 @@ class ManifestAsset extends Asset {
             icons: this.processIcons,
             options_ui: this.processOptionsUi,
             options_page: this.processOptionsPage
+        }
+
+        const _replaceBundleNames = this.replaceBundleNames
+        this.replaceBundleNames = bundleNameMap => {
+            for (const [name, map] of bundleNameMap) {
+                bundleNameMap[name] = upath.toUnix(map)
+            }
+            _replaceBundleNames.call(this, bundleNameMap)
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,7 +3574,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.0.0:
+upath@^1.0.0, upath@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 


### PR DESCRIPTION
Fix manifest paths for Windows #14

This doesn't work. Still trying to find the culprit.