### PR TITLE
Add browser prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ NODE_ENV=development parcel src/manifest.json
 ```
 and the plugin will also look for `manifest.development.json` and merge those keys into the base manifest.
 
+### Manifest prefix
+
+Converts and removes keys with a prefix to the key without prefix.
+For example, you can run:
+```sh
+VENDOR=chrome parcel src/manifest.json
+
+Input:
+{
+    "options_ui": {
+        "firefox|browser_style": true,
+        "chrome|chrome_style": true,
+        "open_in_tab": false
+    }
+}
+
+Result:
+{
+    "options_ui": {
+        "chrome_style": true,
+        "open_in_tab": false
+    }
+}
+
+```
+
 ## Licence
 
 Apache 2.0

--- a/src/ManifestAsset.js
+++ b/src/ManifestAsset.js
@@ -3,6 +3,7 @@ const glob = require('fast-glob')
 const Asset = require('parcel-bundler/src/Asset')
 const JSONAsset = require('parcel-bundler/src/assets/JSONAsset')
 const fs = require('@parcel/fs')
+const applyBrowserPrefixesFor = require('./applyBrowserPrefixesFor')
 
 /**
  * A shared asset that handles:
@@ -68,6 +69,10 @@ class ManifestAsset extends Asset {
         const manifestDir = path.dirname(name)
         const rawBaseManifest = await fs.readFile(name, encoding)
         const baseManifest = JSON.parse(rawBaseManifest)
+        const vendor = process.env.VENDOR || 'chrome'
+
+        // Apply browser prefix
+        applyBrowserPrefixesFor(vendor)(baseManifest)
 
         // Merge overrides
         if (typeof process.env.NODE_ENV === 'string') {

--- a/src/applyBrowserPrefixesFor.js
+++ b/src/applyBrowserPrefixesFor.js
@@ -1,0 +1,56 @@
+/**
+ *  refer to https://github.com/HaNdTriX/generator-chrome-extension-kickstart/blob/master/app/templates/tasks/lib/applyBrowserPrefixesFor.js
+ * 
+ *  Converts and removes keys with a
+ *  prefix to the key without prefix
+ * @param  {String} vendor
+ * @return {Function}
+ */
+module.exports = function applyBrowserPrefixesFor(vendor) {
+    /**
+     * Converts and removes keys with a
+     * prefix to the key without prefix
+     *
+     * Recursive iterator over all object keys
+     *
+     * Example:
+     *
+     *    chrome|keyName
+     *    firefox|keyName
+     *    opera|keyName
+     *    edge|keyName
+     *
+     * to `keyName`.
+     * This way we can write one manifest thats valid
+     * for all browsers
+     *
+     * @param  {Object} manifest
+     * @return {Object}
+     */
+    return function iterator(obj) {
+        Object.keys(obj).forEach(key => {
+            const vbarIndex = key.lastIndexOf('|')
+
+            if (vbarIndex != -1) {
+                const venders = key.substring(0, vbarIndex)
+                const targetKey = key.substring(vbarIndex + 1)
+                // Swap key with non prefixed name
+                if (venders.indexOf(vendor) !== -1) {
+                    obj[targetKey] = obj[key]
+                }
+
+                // Remove the prefixed key
+                // so it won't cause warings
+                delete obj[key]
+            } else {
+                // no match? try deeper
+                // Recurse over object's inner keys
+                if (typeof obj[key] === 'object') {
+                    iterator(obj[key])
+                }
+            }
+        })
+
+        return obj
+    };
+};

--- a/test/integration/manifest-prefix/content_script.js
+++ b/test/integration/manifest-prefix/content_script.js
@@ -1,0 +1,5 @@
+main()
+
+function main() {
+    console.log('Hello, world!')
+}

--- a/test/integration/manifest-prefix/manifest.json
+++ b/test/integration/manifest-prefix/manifest.json
@@ -1,0 +1,29 @@
+{
+    "manifest_version": 2,
+    "name": "parcel-web-extension-test",
+    "version": "1.0.0",
+    "permissions": [],
+    "content_scripts": [
+        {
+            "matches": [
+                "<all_urls>"
+            ],
+            "js": [
+                "content_script.js"
+            ],
+            "run_at": "document_start"
+        }
+    ],
+    "options_ui": {
+        "firefox|browser_style": true,
+        "chrome|chrome_style": true,
+        "open_in_tab": false
+    },
+    "chrome|minimum_chrome_version": "72.0",
+    "firefox|browser_specific_settings": {
+        "gecko": {
+            "id": "test@addon.com",
+            "strict_min_version": "63.0"
+        }
+    }
+}

--- a/test/manifest-prefix.js
+++ b/test/manifest-prefix.js
@@ -1,0 +1,87 @@
+const { bundlerWithPlugin, assertBundleTree } = require('./utils')
+const assert = require('assert')
+
+describe('Manifest prefix', () => {
+    let nodeEnv
+    beforeEach(() => {
+        nodeEnv = process.env.VENDOR
+    })
+    afterEach(() => {
+        process.env.VENDOR = nodeEnv
+    })
+
+    it('should remain chrome prefix key when VENDOR=chrome', async () => {
+        process.env.VENDOR = 'chrome'
+        const bundler = await bundlerWithPlugin(
+            __dirname + '/integration/manifest-prefix/manifest.json'
+        )
+        const bundle = await bundler.bundle()
+
+        await assertBundleTree(bundle, {
+            type: 'json',
+            assets: ['manifest.json'],
+            childBundles: [
+                { name: 'content_script.js' }
+            ]
+        })
+        const finalManifest = JSON.parse(bundle.entryAsset.generated.json)
+        assert.deepStrictEqual(finalManifest, {
+            manifest_version: 2,
+            name: 'parcel-web-extension-test',
+            version: '1.0.0',
+            permissions: [],
+            content_scripts: [
+                {
+                    matches: ['<all_urls>'],
+                    js: ['content_script.js'],
+                    run_at: 'document_start'
+                }
+            ],
+            options_ui: {
+                chrome_style: true,
+                open_in_tab: false
+            },
+            minimum_chrome_version: '72.0'
+        })
+    })
+
+    it('should remain firefox prefix key when VENDOR=firefox', async () => {
+        process.env.VENDOR = 'firefox'
+        const bundler = await bundlerWithPlugin(
+            __dirname + '/integration/manifest-prefix/manifest.json'
+        )
+        const bundle = await bundler.bundle()
+
+        await assertBundleTree(bundle, {
+            type: 'json',
+            assets: ['manifest.json'],
+            childBundles: [
+                { name: 'content_script.js' }
+            ]
+        })
+        const finalManifest = JSON.parse(bundle.entryAsset.generated.json)
+        assert.deepStrictEqual(finalManifest, {
+            manifest_version: 2,
+            name: 'parcel-web-extension-test',
+            version: '1.0.0',
+            permissions: [],
+            content_scripts: [
+                {
+                    matches: ['<all_urls>'],
+                    js: ['content_script.js'],
+                    run_at: 'document_start'
+                }
+            ],
+            options_ui: {
+                browser_style: true,
+                open_in_tab: false
+            },
+            browser_specific_settings: {
+                gecko: {
+                    id: 'test@addon.com',
+                    strict_min_version: '63.0'
+                }
+            }
+        })
+    })
+})


### PR DESCRIPTION
- Converts and removes keys with a prefix to the key without prefix.
- Refer to [applyBrowserPrefixesFor](https://github.com/HaNdTriX/generator-chrome-extension-kickstart/blob/master/app/templates/tasks/lib/applyBrowserPrefixesFor.js)
- Sorry, but I don't know English well.