### PR TITLE
Add support of `default_panel` and  `default_icon` for `sidebar_action`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Assets resolved by this plugin:
 - `browser_action.default_icon`
 - `page_action.default_popup`
 - `page_action.default_icon`
+- `sidebar_action.default_panel`
+- `sidebar_action.default_icon`
 - `icons`
 - `web_accessible_resources`
 - `chrome_url_overrides.bookmarks`

--- a/src/ManifestAsset.js
+++ b/src/ManifestAsset.js
@@ -29,6 +29,7 @@ class ManifestAsset extends Asset {
             web_accessible_resources: this.processWebAccessibleResources,
             browser_action: this.processBrowserAction,
             page_action: this.processPageAction,
+            sidebar_action: this.processSidebarAction,
             icons: this.processIcons,
             options_ui: this.processOptionsUi,
             options_page: this.processOptionsPage,
@@ -224,6 +225,26 @@ class ManifestAsset extends Asset {
         if (action.default_popup) {
             action.default_popup = this.processSingleDependency(
                 action.default_popup
+            )
+        }
+        const defaultIcon = action.default_icon
+        if (defaultIcon) {
+            action.default_icon =
+                typeof defaultIcon === 'string'
+                    ? this.processSingleDependency(defaultIcon)
+                    : this.processAllIcons(defaultIcon)
+        }
+    }
+
+    processSidebarAction() {
+        const action = this.ast.sidebar_action
+        if (!action) {
+            return
+        }
+
+        if (action.default_panel) {
+            action.default_panel = this.processSingleDependency(
+                action.default_panel
             )
         }
         const defaultIcon = action.default_icon

--- a/test/integration/web-extension/manifest.json
+++ b/test/integration/web-extension/manifest.json
@@ -33,6 +33,10 @@
     "options_ui": {
         "page": "options.html"
     },
+    "sidebar_action": {
+        "default_icon": "favicon.ico",
+        "default_panel": "sidebar.html"
+    },
     "web_accessible_resources": [
         "inject.js"
     ]

--- a/test/integration/web-extension/sidebar.html
+++ b/test/integration/web-extension/sidebar.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+
+<head>
+    <script src="sidebar/index.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test/integration/web-extension/sidebar/index.js
+++ b/test/integration/web-extension/sidebar/index.js
@@ -1,0 +1,5 @@
+main()
+
+function main() {
+    console.log('Hello, world!')
+}

--- a/test/web-extension.js
+++ b/test/web-extension.js
@@ -19,7 +19,8 @@ describe('WebExtension', () => {
                 { name: 'favicon.ico' },
                 { name: 'inject.js' },
                 { name: 'options.html' },
-                { name: 'popup.html' }
+                { name: 'popup.html' },
+                { name: 'sidebar.html' }
             ]
         })
 


### PR DESCRIPTION
Add support to `sidebar_action.default_panel` as an entry point, and `sidebar_action.default_icon` as an asset.