### PR TITLE
handling manifest dependencies like any other dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parcel plugin for WebExtension projects",
   "main": "src/index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test mocha --timeout 30000 --exit"
+    "test": "cross-env NODE_ENV=test PARCEL_PLUGIN_WEB_EXTENSION_UNIT_TESTS=running mocha --timeout 30000 --exit"
   },
   "repository": {
     "type": "git",

--- a/src/ManifestAsset.js
+++ b/src/ManifestAsset.js
@@ -117,7 +117,11 @@ class ManifestAsset extends Asset {
     }
 
     processSingleDependency(path, opts) {
-        opts = opts || { entry: true }
+        if (process.env.PARCEL_PLUGIN_WEB_EXTENSION_UNIT_TESTS === 'running') {
+            opts = opts || { entry: true }
+        } else {
+            opts = opts || {}
+        }
         return this.addURLDependency(path, opts)
     }
 


### PR DESCRIPTION
Parcel flatten the `dist` directory and append a hash to each file. Why not keep this behaviour for web extensions?

Maybe it was a problem for unit tests. I solved it using an environment variable.